### PR TITLE
Implemented -l and -r as input parameters

### DIFF
--- a/src/apps/hrtf-mesh-grading.cpp
+++ b/src/apps/hrtf-mesh-grading.cpp
@@ -16,7 +16,7 @@ void usage_and_exit()
               << "-y the maximum edge length in mm\n"
               << "-e the maximum geometrical error in mm (Optional. The minimum edge length by default)\n"
               << "-s the side at which the mesh resolution will be high ('left' or 'right')\n"
-              << "-l, r the left and right y-coordinate of the actual ear channel entrances. "
+              << "-l, r the left and right y-coordinate of the actual ear channel entrances in the unit of the input mesh. "
               << "Note that the gamma scaling factors won't be used if the actual positions are given.\n"
               << "-g, h the scaling factor to estimate the y-coordinate of the left (g) and right (h) ear channel entrance (gamma on p. 1112 in Palm et al.). The default is 0.15. "
               << "Use this if the actual ear channel entrance position is not know and the graded mesh contains to large or too small elements in the vicinity of the ear channels. "

--- a/src/apps/hrtf-mesh-grading.cpp
+++ b/src/apps/hrtf-mesh-grading.cpp
@@ -16,8 +16,11 @@ void usage_and_exit()
               << "-y the maximum edge length in mm\n"
               << "-e the maximum geometrical error in mm (Optional. The minimum edge length by default)\n"
               << "-s the side at which the mesh resolution will be high ('left' or 'right')\n"
+              << "-l, r the left and right y-coordinate of the actual ear channel entrances. "
+              << "Note that the gamma scaling factors won't be used if the actual positions are given.\n"
               << "-g, h the scaling factor to estimate the y-coordinate of the left (g) and right (h) ear channel entrance (gamma on p. 1112 in Palm et al.). The default is 0.15. "
-              << "Use this if the graded mesh contains to large or too small elements in the vicinity of the ear channels. Use the verbose flag to echo the gamma parameters."
+              << "Use this if the actual ear channel entrance position is not know and the graded mesh contains to large or too small elements in the vicinity of the ear channels. "
+              << "Use the verbose flag to echo the gamma parameters. "
               << "The estimated positions should have slightly smaller absolute values than the actual ear channel entrances.\n"
               << "-i the path to the input mesh\n"
               << "-o the path to the output mesh\n"
@@ -38,13 +41,15 @@ int main(int argc, char** argv)
     const char* input = nullptr;
     const char* output = nullptr;
     float min, max, err = 0;
+    float channel_left = 0.;
+    float channel_right = 0.;
     float gamma_scaling_left = 2.;
     float gamma_scaling_right = 2.;
     const char* ear = nullptr;
 
     // parse command line parameters ------------------------------------------
     int c;
-    while ((c = getopt(argc, argv, "x:y:e:s:g:h:i:o:vi:bi:")) != -1)
+    while ((c = getopt(argc, argv, "x:y:e:s:l:r:g:h:i:o:vi:bi:")) != -1)
     {
         switch (c)
         {
@@ -62,6 +67,14 @@ int main(int argc, char** argv)
 
             case 's':
                 ear = optarg;
+                break;
+            
+            case 'l':
+                channel_left = std::stof(optarg);
+                break;
+
+            case 'r':
+                channel_right = std::stof(optarg);
                 break;
 
             case 'g':
@@ -121,8 +134,12 @@ int main(int argc, char** argv)
         std::cout << "min. edge length: " << min << std::endl;
         std::cout << "max. edge length: " << max << std::endl;
         std::cout << "max. error: " << err << std::endl;
-        std::cout << "gamma scaling left/right: "
-            << gamma_scaling_left << "/" << gamma_scaling_right << std::endl;
+        if (channel_left == 0. && channel_right == 0.)
+        {
+            std::cout << "gamma scaling left/right: "
+                << gamma_scaling_left << "/" << gamma_scaling_right << std::endl;
+        } 
+
     }
 
     // load input mesh --------------------------------------------------------
@@ -147,6 +164,8 @@ int main(int argc, char** argv)
                     10U,
                     true,
                     ear,
+                    channel_left,
+                    channel_right,
                     gamma_scaling_left, gamma_scaling_right,
                     verbose
                     );

--- a/src/pmp/algorithms/SurfaceRemeshing.cpp
+++ b/src/pmp/algorithms/SurfaceRemeshing.cpp
@@ -64,6 +64,8 @@ void SurfaceRemeshing::adaptive_remeshing(Scalar min_edge_length,
                                           unsigned int iterations,
                                           bool use_projection,
                                           std::string ear,
+                                          Scalar channel_left,
+                                          Scalar channel_right,
                                           Scalar gamma_scaling_left,
                                           Scalar gamma_scaling_right,
                                           bool verbose)
@@ -74,7 +76,7 @@ void SurfaceRemeshing::adaptive_remeshing(Scalar min_edge_length,
     approx_error_ = approx_error;
     use_projection_ = use_projection;
 
-    preprocessing(ear, gamma_scaling_left, gamma_scaling_right, verbose);
+    preprocessing(ear, channel_left, channel_right, gamma_scaling_left, gamma_scaling_right, verbose);
 
     for (unsigned int i = 0; i < iterations; ++i)
     {
@@ -95,6 +97,8 @@ void SurfaceRemeshing::adaptive_remeshing(Scalar min_edge_length,
 }
 
 void SurfaceRemeshing::preprocessing(std::string ear,
+                                     Scalar channel_left,
+                                     Scalar channel_right,
                                      Scalar gamma_scaling_left,
                                      Scalar gamma_scaling_right,
                                      bool verbose)
@@ -239,15 +243,47 @@ void SurfaceRemeshing::preprocessing(std::string ear,
         }
 
         // approximate the blocked ear canal positions
-        float min_y = b2.min()[1] + (b2.max()[1] - b2.min()[1]) * gamma_scaling_right; // right
+        float min_y;
+        float max_y;
         float min_z = bb.min()[2] + (bb.max()[2] - bb.min()[2]) * 0.22;
-        float max_y = b2.max()[1] - (b2.max()[1] - b2.min()[1]) * gamma_scaling_left; // left
+        if (channel_right == 0.)
+        {
+            min_y = b2.min()[1] + (b2.max()[1] - b2.min()[1]) * gamma_scaling_right; // right 
+        }     
+        else
+        { 
+            min_y = channel_right;
+        }  
+        if (channel_left == 0.)
+        {
+            max_y = b2.max()[1] - (b2.max()[1] - b2.min()[1]) * gamma_scaling_left; // left
+        } 
+        else
+        { 
+            max_y = channel_left;
+        } 
 
         if (verbose){
-            std::cout << "\nestimated ear channel entrance left:   "
-                << max_y << "/0/0 mm (y/x/z)" << std::endl;
-            std::cout << "estimated ear channel entrance right: "
-                << min_y << "/0/0 mm (y/x/z)" << std::endl;
+            if (channel_left != 0.)
+            {
+                std::cout << "\near channel entrance left:   "
+                    << max_y << "/0/0 " << unit << " (y/x/z)" << std::endl; 
+            }
+            else
+            { 
+                std::cout << "\nestimated ear channel entrance left:   "
+                    << max_y << "/0/0 " << unit << " (y/x/z)" << std::endl;
+            } 
+            if (channel_right != 0.)
+            {
+                std::cout << "\near channel entrance right:   "
+                    << min_y << "/0/0 " << unit << " (y/x/z)" << std::endl; 
+            }
+            else
+            { 
+                std::cout << "\nestimated ear channel entrance left:   "
+                    << min_y << "/0/0 " << unit << " (y/x/z)" << std::endl;
+            } 
         }
 
         // now convert per-vertex curvature into target edge length

--- a/src/pmp/algorithms/SurfaceRemeshing.cpp
+++ b/src/pmp/algorithms/SurfaceRemeshing.cpp
@@ -185,6 +185,14 @@ void SurfaceRemeshing::preprocessing(std::string ear,
             min_edge_length_ *= 0.001;
             approx_error_ *= 0.001;
         }
+        if (unit = "m" && channel_left > 10)
+        {
+            channel_left *= 0.001;
+        }
+        if (unit = "m" && channel_right > 10)
+        {
+            channel_right *= 0.001;
+        } 
 
         if (ear != "none")
         {

--- a/src/pmp/algorithms/SurfaceRemeshing.cpp
+++ b/src/pmp/algorithms/SurfaceRemeshing.cpp
@@ -185,11 +185,11 @@ void SurfaceRemeshing::preprocessing(std::string ear,
             min_edge_length_ *= 0.001;
             approx_error_ *= 0.001;
         }
-        if (unit = "m" && channel_left > 10)
+        if (unit == "m" && channel_left > 10)
         {
             channel_left *= 0.001;
         }
-        if (unit = "m" && channel_right > 10)
+        if (unit == "m" && channel_right > 10)
         {
             channel_right *= 0.001;
         } 

--- a/src/pmp/algorithms/SurfaceRemeshing.cpp
+++ b/src/pmp/algorithms/SurfaceRemeshing.cpp
@@ -185,14 +185,6 @@ void SurfaceRemeshing::preprocessing(std::string ear,
             min_edge_length_ *= 0.001;
             approx_error_ *= 0.001;
         }
-        if (unit == "m" && channel_left > 10)
-        {
-            channel_left *= 0.001;
-        }
-        if (unit == "m" && channel_right > 10)
-        {
-            channel_right *= 0.001;
-        } 
 
         if (ear != "none")
         {

--- a/src/pmp/algorithms/SurfaceRemeshing.h
+++ b/src/pmp/algorithms/SurfaceRemeshing.h
@@ -42,13 +42,16 @@ public:
     void adaptive_remeshing(Scalar min_edge_length, Scalar max_edge_length,
                             Scalar approx_error, unsigned int iterations = 10,
                             bool use_projection = true, std::string ear = "none",
+                            Scalar channel_left = 0.,
+                            Scalar channel_right = 0.,
                             Scalar gamma_scaling_left = 0.15,
                             Scalar gamma_scaling_right = 0.15,
                             bool verbose = false);
 
 private:
     void preprocessing(std::string ear, Scalar gamma_scaling_left = 0.15,
-                       Scalar gamma_scaling_right = 0.15, bool verbose = false);
+                       Scalar gamma_scaling_right = 0.15, Scalar channel_left = 0.,
+                       Scalar channel_right = 0., bool verbose = false);
     void postprocessing();
 
     void split_long_edges();


### PR DESCRIPTION
# Description

Implemented Code to pass actual ear channel y-values to hrtf_mesh_grading.

# Motivation

When the actual position is know, it makes sence not to use the gamma_scaling and use the actual positions instead. 

