### PR TITLE
Fix typo for estimated right ear

### DIFF
--- a/src/pmp/algorithms/SurfaceRemeshing.cpp
+++ b/src/pmp/algorithms/SurfaceRemeshing.cpp
@@ -281,7 +281,7 @@ void SurfaceRemeshing::preprocessing(std::string ear,
             }
             else
             { 
-                std::cout << "\nestimated ear channel entrance left:   "
+                std::cout << "\nestimated ear channel entrance right:   "
                     << min_y << "/0/0 " << unit << " (y/x/z)" << std::endl;
             } 
         }


### PR DESCRIPTION
# Description

Fix a typo I encountered when grading my mesh with `hrtf_mesh_grading`

# Motivation

Right now it looks like the tool detects two left ears.
